### PR TITLE
Tim/support exec query

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ SqlQuery.new('player/get_by_email', email: 'e@mail.dev')
 ### Methods
 
 - **execute** - executes query and returns result data. It accepts boolean argument. When argument is false it will run raw sql query instead of prepared_for_logs.
+- **exec_query** - similar to `#execute` but with data returned via `ActiveRecord::Result`.
 - **explain** - runs explain for SQL from template
 - **sql** - returns SQL string
 - **pretty_sql** - returns SQL string prettier to read in console

--- a/README.md
+++ b/README.md
@@ -142,3 +142,10 @@ If you have some examples to share please make pull request.
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create a new Pull Request
+
+To run specs, setup Postgres with the following:
+
+```sql
+CREATE DATABASE sqlquery;
+CREATE ROLE sqlquery WITH LOGIN;
+```

--- a/lib/sql_query.rb
+++ b/lib/sql_query.rb
@@ -27,6 +27,11 @@ class SqlQuery
     connection.execute(to_execute).entries
   end
 
+  def exec_query(prepare = true)
+    to_execute = prepare ? prepared_for_logs : sql
+    connection.exec_query(to_execute).to_a
+  end
+
   def sql
     @sql ||= ERB.new(File.read(file_path)).result(binding)
   end

--- a/spec/sql_query_spec.rb
+++ b/spec/sql_query_spec.rb
@@ -145,6 +145,38 @@ describe SqlQuery do
     end
   end
 
+  describe '#exec_query' do
+    before do
+      ActiveRecord::Base.connection.execute(
+        "INSERT INTO players (email) VALUES ('e@mail.dev')"
+      )
+    end
+
+    after do
+      ActiveRecord::Base.connection.execute(
+        'DELETE FROM players'
+      )
+    end
+
+    it 'returns data from database' do
+      expect(query.exec_query).to eq [{ 'email' => 'e@mail.dev' }]
+    end
+
+    context 'when prepare argument is true' do
+      it 'executes prepared query for logs' do
+        expect(query).to receive(:prepared_for_logs) { '' }
+        query.exec_query
+      end
+    end
+
+    context 'when prepare argument is false' do
+      it 'executes unchanged sql query' do
+        expect(query).not_to receive(:prepared_for_logs)
+        query.exec_query(false)
+      end
+    end
+  end
+
   describe '#partial' do
     let(:file_name) { :get_player_by_email_with_template }
     it 'resolves partials as parts of sql queries' do


### PR DESCRIPTION
Note that the specs ended up being identical to `#execute` because the `PG::Result` gives the same results as `ActiveRecord::Result`. However, `MySql::Result#entries` instead returns an array of arrays and does not allow using column names as keys, which is where `exec_query` helps.