### PR TITLE
Set active record dependency to <= 7.0

### DIFF
--- a/sql_query.gemspec
+++ b/sql_query.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  spec.add_dependency 'activerecord', '>= 3.2', '< 6.2'
+  spec.add_dependency 'activerecord', '>= 3.2', '<= 7.0'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'pg', '~> 0.18'


### PR DESCRIPTION
The gem doesn't work with Rails 7.0 because of a broken ActiveRecord dependency.  This PR fixes this.