### PR TITLE
Issue #15 - Kept multiple whitespace in embedded params using gsub only on query template.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ gemfile:
   - gemfiles/5.0.gemfile
 
 rvm:
-  - '2.3.3'
+  - '2.6.0'
 
 addons:
   postgresql: '9.4'

--- a/lib/sql_query.rb
+++ b/lib/sql_query.rb
@@ -34,7 +34,7 @@ class SqlQuery
   end
 
   def sql
-    @sql ||= ERB.new(File.read(file_path)).result(binding)
+    @sql ||= prepare_query(false)
   end
 
   def pretty_sql
@@ -46,7 +46,7 @@ class SqlQuery
   end
 
   def prepared_for_logs
-    sql.gsub(/(\n|\s)+/, ' ')
+    @sql_for_logs ||= prepare_query(true)
   end
 
   def partial(partial_name, partial_options = {})
@@ -74,6 +74,12 @@ class SqlQuery
   end
 
   private
+
+  def prepare_query(for_logs)
+    query_template = File.read(file_path)
+    query_template = query_template.gsub(/(\n|\s)+/, ' ') if for_logs
+    ERB.new(query_template).result(binding)
+  end
 
   def split_to_path_and_name(file)
     if file.is_a?(Symbol)

--- a/spec/sql_query_spec.rb
+++ b/spec/sql_query_spec.rb
@@ -201,6 +201,16 @@ describe SqlQuery do
       expect(query.prepared_for_logs)
         .to eq("SELECT * FROM players WHERE email = 'e@mail.dev' ")
     end
+
+    context 'when embedded params have multiple whitespaces' do
+      let(:options) { { email: '   e@mail.dev   ' } }
+      let(:query) { described_class.new(file_name, options) }
+
+      it 'returns string without multiple whitespaces except embedded params' do
+        expect(query.prepared_for_logs)
+          .to eq("SELECT * FROM players WHERE email = '   e@mail.dev   ' ")
+      end
+    end
   end
 
   describe '.config' do


### PR DESCRIPTION
Updated travis.yml to Ruby 2.6.0 to avoid bundler install error.