### PR TITLE
Add configurable SQL comment removal feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.7.5 / Unreleased
 
-* [Added]
+* [Added] Configurable SQL comment removal feature with `remove_comments` and `remove_comments_from` configuration options. Supports selective removal of single-line (`--`) and multi-line (`/* */`) comments while preserving comments within quoted strings (single, double, and PostgreSQL dollar quotes). Addresses https://github.com/sufleR/sql_query/issues/20
 
 * [Deprecated]
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ SqlQuery.new('player/get_by_email', email: 'e@mail.dev')
 SqlQuery.configure do |config|
   config.path = '/app/sql_templates'
   config.adapter = ActiveRecord::Base
+  config.remove_comments = :all              # :none, :oneline, :multiline, :all (default: :all)
+  config.remove_comments_from = :all         # :none, :prepared_for_logs, :all (default: :all)
 end
 ```
 
@@ -106,6 +108,19 @@ end
 * path - If you don't like default path to your queries you can change it here.
 
 * adapter - class which implements connection method.
+
+* remove_comments - Controls which types of SQL comments to remove:
+  * `:none` - Don't remove any comments
+  * `:oneline` - Remove only single-line comments (`--`)
+  * `:multiline` - Remove only multi-line comments (`/* */`)
+  * `:all` - Remove both types (default)
+
+* remove_comments_from - Controls where to apply comment removal:
+  * `:none` - Don't remove comments anywhere
+  * `:prepared_for_logs` - Remove comments only in `prepared_for_logs` method
+  * `:all` - Remove comments from all queries (default)
+
+**Note:** Comments within quoted strings (single quotes, double quotes, or PostgreSQL dollar quotes) are always preserved regardless of settings.
 
 ### Partials
 

--- a/lib/sql_query.rb
+++ b/lib/sql_query.rb
@@ -85,10 +85,7 @@ class SqlQuery
   end
 
   def apply_comment_removal(sql, for_logs:)
-    config = self.class.config
-    return sql unless config.should_comments_be_removed?(for_logs: for_logs)
-
-    CommentRemover.new(config.remove_comments).remove(sql)
+    CommentRemover.new(self.class.config).remove(sql, for_logs: for_logs)
   end
 
   def pretty(value)

--- a/lib/sql_query.rb
+++ b/lib/sql_query.rb
@@ -4,7 +4,6 @@ require 'erb'
 require_relative 'sql_query/config'
 require_relative 'sql_query/comment_remover'
 
-# rubocop:disable Metrics/ClassLength
 class SqlQuery
   attr_reader :connection
 
@@ -37,10 +36,7 @@ class SqlQuery
   end
 
   def sql
-    @sql ||= begin
-      rendered_sql = prepare_query(false)
-      apply_comment_removal(rendered_sql, for_logs: false)
-    end
+    @sql ||= apply_comment_removal(prepare_query(false), for_logs: false)
   end
 
   def pretty_sql
@@ -52,10 +48,7 @@ class SqlQuery
   end
 
   def prepared_for_logs
-    @prepared_for_logs ||= begin
-      rendered_sql = prepare_query(true)
-      apply_comment_removal(rendered_sql, for_logs: true)
-    end
+    @prepared_for_logs ||= apply_comment_removal(prepare_query(true), for_logs: true)
   end
 
   def partial(partial_name, partial_options = {})
@@ -138,4 +131,3 @@ class SqlQuery
     tmp_path
   end
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/sql_query/comment_remover.rb
+++ b/lib/sql_query/comment_remover.rb
@@ -1,0 +1,211 @@
+# frozen_string_literal: true
+
+class SqlQuery
+  # Service class responsible for removing SQL comments from queries
+  # while preserving content within quoted strings.
+  #
+  # Supports SQL-92 standard comment syntax:
+  # - Single-line comments: -- comment
+  # - Multi-line comments: /* comment */
+  #
+  # Preserves content in:
+  # - Single-quoted strings: '...'
+  # - Double-quoted identifiers: "..."
+  # - Dollar-quoted strings (PostgreSQL): $$...$$ or $tag$...$tag$
+  #
+  # @example
+  #   remover = CommentRemover.new(:all)
+  #   sql = "SELECT * FROM t -- comment\nWHERE id = 1"
+  #   remover.remove(sql)
+  #   # => "SELECT * FROM t \nWHERE id = 1"
+  #
+  # rubocop:disable Metrics/ClassLength
+  class CommentRemover
+    def initialize(strategy)
+      @strategy = strategy # :none, :oneline, :multiline, :all
+    end
+
+    # Removes comments from SQL based on the configured strategy
+    #
+    # @param sql [String] the SQL string to process
+    # @return [String] SQL with comments removed (or unchanged if strategy is :none)
+    def remove(sql)
+      return sql if @strategy == :none
+
+      state = init_state
+      result = []
+      i = 0
+
+      i = process_character(sql, i, result, state) while i < sql.length
+
+      result.join
+    end
+
+    private
+
+    def init_state
+      {
+        in_single: false,       # Inside '...'
+        in_double: false,       # Inside "..."
+        in_dollar: false,       # Inside $$...$$ or $tag$...$tag$
+        dollar_tag: nil,        # Current dollar quote tag
+        in_line_comment: false, # Inside -- comment
+        in_block_comment: false, # Inside /* */ comment
+        escape_next: false # Next char is escaped (for backslash escapes)
+      }
+    end
+
+    # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/PerceivedComplexity, Metrics/AbcSize
+    def process_character(sql, index, result, state)
+      char = sql[index]
+      next_char = index + 1 < sql.length ? sql[index + 1] : nil
+
+      # Handle escape sequences
+      if state[:escape_next]
+        result << char unless in_comment?(state)
+        state[:escape_next] = false
+        return index + 1
+      end
+
+      # Check for backslash escape
+      if char == '\\' && (state[:in_single] || state[:in_double])
+        result << char unless in_comment?(state)
+        state[:escape_next] = true
+        return index + 1
+      end
+
+      # If in comment, check for comment end
+      if state[:in_line_comment]
+        if char == "\n"
+          state[:in_line_comment] = false
+          result << char # Preserve newline
+        end
+        # Skip comment content
+        return index + 1
+      end
+
+      if state[:in_block_comment]
+        if char == '*' && next_char == '/'
+          state[:in_block_comment] = false
+          return index + 2 # Skip */
+        end
+        # Skip comment content
+        return index + 1
+      end
+
+      # Not in comment - check for comment start (only if not in quotes)
+      unless in_quote?(state)
+        if char == '-' && next_char == '-' && should_remove_oneline?
+          state[:in_line_comment] = true
+          return index + 2 # Skip --
+        end
+
+        if char == '/' && next_char == '*' && should_remove_multiline?
+          state[:in_block_comment] = true
+          return index + 2 # Skip /*
+        end
+      end
+
+      # Handle quotes
+      if char == "'" && !state[:in_double] && !state[:in_dollar]
+        if state[:in_single] && next_char == "'"
+          # Escaped single quote (SQL style: '')
+          result << char << next_char
+          return index + 2
+        else
+          state[:in_single] = !state[:in_single]
+          result << char
+          return index + 1
+        end
+      end
+
+      if char == '"' && !state[:in_single] && !state[:in_dollar]
+        if state[:in_double] && next_char == '"'
+          # Escaped double quote
+          result << char << next_char
+          return index + 2
+        else
+          state[:in_double] = !state[:in_double]
+          result << char
+          return index + 1
+        end
+      end
+
+      # Handle dollar quotes (PostgreSQL)
+      if char == '$' && !state[:in_single] && !state[:in_double]
+        tag, tag_length = extract_dollar_tag(sql, index)
+        if tag
+          if state[:in_dollar] && tag == state[:dollar_tag]
+            # Closing dollar quote
+            state[:in_dollar] = false
+            state[:dollar_tag] = nil
+            tag_length.times { |i| result << sql[index + i] }
+            return index + tag_length
+          elsif !state[:in_dollar]
+            # Opening dollar quote
+            state[:in_dollar] = true
+            state[:dollar_tag] = tag
+            tag_length.times { |i| result << sql[index + i] }
+            return index + tag_length
+          end
+        end
+      end
+
+      # Regular character
+      result << char
+      index + 1
+    end
+    # rubocop:enable Metrics/MethodLength, Metrics/CyclomaticComplexity
+    # rubocop:enable Metrics/PerceivedComplexity, Metrics/AbcSize
+
+    def in_quote?(state)
+      state[:in_single] || state[:in_double] || state[:in_dollar]
+    end
+
+    def in_comment?(state)
+      state[:in_line_comment] || state[:in_block_comment]
+    end
+
+    def should_remove_oneline?
+      @strategy == :oneline || @strategy == :all
+    end
+
+    def should_remove_multiline?
+      @strategy == :multiline || @strategy == :all
+    end
+
+    # Extracts dollar quote tag from position
+    # Returns [tag, length] or [nil, nil]
+    # Matches: $$ or $tag$ where tag is alphanumeric/underscore
+    # rubocop:disable Metrics/MethodLength
+    def extract_dollar_tag(sql, index)
+      return [nil, nil] unless sql[index] == '$'
+
+      # Look for closing $
+      i = index + 1
+      tag_chars = []
+
+      while i < sql.length
+        char = sql[i]
+        if char == '$'
+          # Found closing $
+          tag = tag_chars.empty? ? '' : tag_chars.join
+          length = i - index + 1
+          return [tag, length]
+        elsif char =~ /[a-zA-Z0-9_]/
+          tag_chars << char
+          i += 1
+        else
+          # Invalid character for dollar quote tag
+          return [nil, nil]
+        end
+      end
+
+      # No closing $ found
+      [nil, nil]
+    end
+    # rubocop:enable Metrics/MethodLength
+  end
+  # rubocop:enable Metrics/ClassLength
+end

--- a/lib/sql_query/config.rb
+++ b/lib/sql_query/config.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class SqlQuery
+  # Configuration class for SqlQuery behavior
+  #
+  # @example
+  #   SqlQuery.configure do |config|
+  #     config.path = '/app/sql_queries'
+  #     config.adapter = ActiveRecord::Base
+  #     config.remove_comments = :all
+  #     config.remove_comments_from = :prepared_for_logs
+  #   end
+  class Config
+    attr_accessor :path, :adapter, :remove_comments, :remove_comments_from
+
+    def initialize
+      @path = '/app/sql_queries'
+      @adapter = ActiveRecord::Base
+      @remove_comments = :all        # :none, :oneline, :multiline, :all
+      @remove_comments_from = :all   # :none, :prepared_for_logs, :all
+    end
+
+    # Determines if comments should be removed for a given context
+    #
+    # @param for_logs [Boolean] whether the query is being prepared for logs
+    # @return [Boolean] true if comments should be removed
+    def should_comments_be_removed?(for_logs:)
+      case remove_comments_from
+      when :prepared_for_logs
+        for_logs
+      when :all
+        true
+      else
+        false
+      end
+    end
+  end
+end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -3,13 +3,73 @@
 require 'spec_helper'
 
 describe SqlQuery::Config do
+  let(:config) { described_class.new }
+
   describe 'initialize' do
     it 'sets path to default' do
-      expect(described_class.new.path).to eq('/app/sql_queries')
+      expect(config.path).to eq('/app/sql_queries')
     end
 
     it 'sets adapter to ActiveRecord::Base' do
-      expect(described_class.new.adapter).to eq(ActiveRecord::Base)
+      expect(config.adapter).to eq(ActiveRecord::Base)
+    end
+
+    it 'sets remove_comments to :all by default' do
+      expect(config.remove_comments).to eq(:all)
+    end
+
+    it 'sets remove_comments_from to :all by default' do
+      expect(config.remove_comments_from).to eq(:all)
+    end
+  end
+
+  describe '#should_comments_be_removed?' do
+    context 'when remove_comments_from is :all' do
+      before { config.remove_comments_from = :all }
+
+      it 'returns true for logs' do
+        expect(config.should_comments_be_removed?(for_logs: true)).to be true
+      end
+
+      it 'returns true for non-logs' do
+        expect(config.should_comments_be_removed?(for_logs: false)).to be true
+      end
+    end
+
+    context 'when remove_comments_from is :prepared_for_logs' do
+      before { config.remove_comments_from = :prepared_for_logs }
+
+      it 'returns true for logs' do
+        expect(config.should_comments_be_removed?(for_logs: true)).to be true
+      end
+
+      it 'returns false for non-logs' do
+        expect(config.should_comments_be_removed?(for_logs: false)).to be false
+      end
+    end
+
+    context 'when remove_comments_from is :none' do
+      before { config.remove_comments_from = :none }
+
+      it 'returns false for logs' do
+        expect(config.should_comments_be_removed?(for_logs: true)).to be false
+      end
+
+      it 'returns false for non-logs' do
+        expect(config.should_comments_be_removed?(for_logs: false)).to be false
+      end
+    end
+
+    context 'when remove_comments_from is an unknown value' do
+      before { config.remove_comments_from = :unknown }
+
+      it 'returns false for logs' do
+        expect(config.should_comments_be_removed?(for_logs: true)).to be false
+      end
+
+      it 'returns false for non-logs' do
+        expect(config.should_comments_be_removed?(for_logs: false)).to be false
+      end
     end
   end
 end

--- a/spec/sql_queries/with_comments_in_strings.sql.erb
+++ b/spec/sql_queries/with_comments_in_strings.sql.erb
@@ -1,0 +1,6 @@
+SELECT
+  '-- not a comment' as text1,
+  '/* also not a comment */' as text2,
+  "column--name" as text3
+FROM players
+WHERE email = <%= quote @email %>

--- a/spec/sql_queries/with_dollar_quotes.sql.erb
+++ b/spec/sql_queries/with_dollar_quotes.sql.erb
@@ -1,0 +1,5 @@
+SELECT
+  $$text with -- comment$$ as text1,
+  $tag$text with /* comment */$tag$ as text2
+FROM players
+WHERE email = <%= quote @email %>

--- a/spec/sql_queries/with_mixed_comments.sql.erb
+++ b/spec/sql_queries/with_mixed_comments.sql.erb
@@ -1,0 +1,4 @@
+-- Single line comment
+SELECT * /* inline comment */ FROM players
+WHERE email = <%= quote @email %> /* another comment */
+-- End comment

--- a/spec/sql_queries/with_multiline_comments.sql.erb
+++ b/spec/sql_queries/with_multiline_comments.sql.erb
@@ -1,0 +1,5 @@
+/* This query selects all players
+   filtered by email address */
+SELECT * FROM players
+WHERE email = <%= quote @email %>
+/* End of query */

--- a/spec/sql_queries/with_single_line_comments.sql.erb
+++ b/spec/sql_queries/with_single_line_comments.sql.erb
@@ -1,0 +1,4 @@
+-- This is a single-line comment at the start
+SELECT * FROM players
+WHERE email = <%= quote @email %> -- filter by email
+-- Another comment at the end

--- a/spec/sql_query/comment_remover_spec.rb
+++ b/spec/sql_query/comment_remover_spec.rb
@@ -1,0 +1,218 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SqlQuery::CommentRemover do
+  describe '#remove' do
+    context 'with strategy :none' do
+      let(:remover) { described_class.new(:none) }
+
+      it 'returns SQL unchanged' do
+        sql = "SELECT * FROM t -- comment\nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+    end
+
+    context 'with strategy :oneline' do
+      let(:remover) { described_class.new(:oneline) }
+
+      it 'removes single-line comments' do
+        sql = "SELECT * FROM t -- comment\nWHERE id = 1"
+        expected = "SELECT * FROM t \nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'removes comment at end of file without newline' do
+        sql = 'SELECT * FROM t --comment'
+        expected = 'SELECT * FROM t '
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'keeps multi-line comments' do
+        sql = "SELECT * FROM t /* comment */\nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves -- in single-quoted strings' do
+        sql = "SELECT '-- not a comment' FROM t"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves -- in double-quoted identifiers' do
+        sql = 'SELECT "column--name" FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves -- in dollar-quoted strings' do
+        sql = 'SELECT $$text with -- comment$$ FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+    end
+
+    context 'with strategy :multiline' do
+      let(:remover) { described_class.new(:multiline) }
+
+      it 'removes multi-line comments' do
+        sql = "SELECT * /* comment */ FROM t\nWHERE id = 1"
+        expected = "SELECT *  FROM t\nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'removes multi-line comments spanning multiple lines' do
+        sql = "SELECT * /* comment\nspanning lines */ FROM t"
+        expected = 'SELECT *  FROM t'
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'keeps single-line comments' do
+        sql = "SELECT * FROM t -- comment\nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves /* */ in single-quoted strings' do
+        sql = "SELECT '/* not a comment */' FROM t"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves /* */ in double-quoted identifiers' do
+        sql = 'SELECT "column/* name */" FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves /* */ in dollar-quoted strings' do
+        sql = 'SELECT $$text with /* comment */$$ FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+    end
+
+    context 'with strategy :all' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'removes both single-line and multi-line comments' do
+        sql = "SELECT * /* inline */ FROM t -- end\nWHERE id = 1"
+        expected = "SELECT *  FROM t \nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'removes multiple comments of different types' do
+        sql = "-- start\nSELECT /* c1 */ * /* c2 */ FROM t -- end"
+        expected = "\nSELECT  *  FROM t "
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'preserves comments in all quote types' do
+        sql = "SELECT '-- c1', \"-- c2\", $$-- c3$$ FROM t"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+    end
+
+    context 'with escaped quotes' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'handles SQL-style escaped single quotes' do
+        sql = "SELECT 'it''s' FROM t -- comment"
+        expected = "SELECT 'it''s' FROM t "
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'handles SQL-style escaped double quotes' do
+        sql = 'SELECT "col""name" FROM t -- comment'
+        expected = 'SELECT "col""name" FROM t '
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'handles backslash-escaped quotes' do
+        sql = "SELECT 'it\\'s' FROM t -- comment"
+        expected = "SELECT 'it\\'s' FROM t "
+        expect(remover.remove(sql)).to eq(expected)
+      end
+    end
+
+    context 'with dollar-quoted strings' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'preserves comments in simple dollar quotes' do
+        sql = 'SELECT $$text with -- comment$$ FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves comments in tagged dollar quotes' do
+        sql = 'SELECT $tag$text with /* comment */$tag$ FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'handles multiple dollar-quoted strings' do
+        sql = 'SELECT $$-- c1$$, $t$/* c2 */$t$ FROM t -- real comment'
+        expected = 'SELECT $$-- c1$$, $t$/* c2 */$t$ FROM t '
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'handles nested dollar quotes with different tags' do
+        sql = 'SELECT $outer$text $inner$nested$inner$$outer$ FROM t'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+    end
+
+    context 'with inline comments' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'removes inline block comments' do
+        sql = 'SELECT /* comment */ column FROM t'
+        expected = 'SELECT  column FROM t'
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'removes multiple inline comments' do
+        sql = 'SELECT /* c1 */ col1, /* c2 */ col2 FROM t'
+        expected = 'SELECT  col1,  col2 FROM t'
+        expect(remover.remove(sql)).to eq(expected)
+      end
+    end
+
+    context 'with comments containing quotes' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'handles single-line comments with quotes' do
+        sql = "SELECT * FROM t -- comment with 'quotes' and \"more\"\nWHERE id = 1"
+        expected = "SELECT * FROM t \nWHERE id = 1"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'handles multi-line comments with quotes' do
+        sql = "SELECT * FROM t /* comment with 'quotes' and \"more\" */ WHERE id = 1"
+        expected = 'SELECT * FROM t  WHERE id = 1'
+        expect(remover.remove(sql)).to eq(expected)
+      end
+    end
+
+    context 'with edge cases' do
+      let(:remover) { described_class.new(:all) }
+
+      it 'handles empty SQL' do
+        expect(remover.remove('')).to eq('')
+      end
+
+      it 'handles SQL with only comments' do
+        sql = "-- comment 1\n/* comment 2 */"
+        expected = "\n"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+
+      it 'handles SQL with no comments' do
+        sql = 'SELECT * FROM t WHERE id = 1'
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'handles comment-like patterns that are not comments' do
+        sql = "SELECT * FROM t WHERE url = 'http://example.com' AND x = 1"
+        expect(remover.remove(sql)).to eq(sql)
+      end
+
+      it 'preserves newlines from removed single-line comments' do
+        sql = "SELECT *\n-- comment\nFROM t"
+        expected = "SELECT *\n\nFROM t"
+        expect(remover.remove(sql)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/sql_query/comment_remover_spec.rb
+++ b/spec/sql_query/comment_remover_spec.rb
@@ -3,215 +3,276 @@
 require 'spec_helper'
 
 RSpec.describe SqlQuery::CommentRemover do
+  # Helper to create config with specific settings
+  def build_config(remove_comments:, remove_comments_from: :all)
+    config = SqlQuery::Config.new
+    config.remove_comments = remove_comments
+    config.remove_comments_from = remove_comments_from
+    config
+  end
+
   describe '#remove' do
     context 'with strategy :none' do
-      let(:remover) { described_class.new(:none) }
+      let(:config) { build_config(remove_comments: :none) }
+      let(:remover) { described_class.new(config) }
 
       it 'returns SQL unchanged' do
         sql = "SELECT * FROM t -- comment\nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
     end
 
     context 'with strategy :oneline' do
-      let(:remover) { described_class.new(:oneline) }
+      let(:config) { build_config(remove_comments: :oneline) }
+      let(:remover) { described_class.new(config) }
 
       it 'removes single-line comments' do
         sql = "SELECT * FROM t -- comment\nWHERE id = 1"
         expected = "SELECT * FROM t \nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'removes comment at end of file without newline' do
         sql = 'SELECT * FROM t --comment'
         expected = 'SELECT * FROM t '
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'keeps multi-line comments' do
         sql = "SELECT * FROM t /* comment */\nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves -- in single-quoted strings' do
         sql = "SELECT '-- not a comment' FROM t"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves -- in double-quoted identifiers' do
         sql = 'SELECT "column--name" FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves -- in dollar-quoted strings' do
         sql = 'SELECT $$text with -- comment$$ FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
     end
 
     context 'with strategy :multiline' do
-      let(:remover) { described_class.new(:multiline) }
+      let(:config) { build_config(remove_comments: :multiline) }
+      let(:remover) { described_class.new(config) }
 
       it 'removes multi-line comments' do
         sql = "SELECT * /* comment */ FROM t\nWHERE id = 1"
         expected = "SELECT *  FROM t\nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'removes multi-line comments spanning multiple lines' do
         sql = "SELECT * /* comment\nspanning lines */ FROM t"
         expected = 'SELECT *  FROM t'
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'keeps single-line comments' do
         sql = "SELECT * FROM t -- comment\nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves /* */ in single-quoted strings' do
         sql = "SELECT '/* not a comment */' FROM t"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves /* */ in double-quoted identifiers' do
         sql = 'SELECT "column/* name */" FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves /* */ in dollar-quoted strings' do
         sql = 'SELECT $$text with /* comment */$$ FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
     end
 
     context 'with strategy :all' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'removes both single-line and multi-line comments' do
         sql = "SELECT * /* inline */ FROM t -- end\nWHERE id = 1"
         expected = "SELECT *  FROM t \nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'removes multiple comments of different types' do
         sql = "-- start\nSELECT /* c1 */ * /* c2 */ FROM t -- end"
         expected = "\nSELECT  *  FROM t "
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'preserves comments in all quote types' do
         sql = "SELECT '-- c1', \"-- c2\", $$-- c3$$ FROM t"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
     end
 
     context 'with escaped quotes' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'handles SQL-style escaped single quotes' do
         sql = "SELECT 'it''s' FROM t -- comment"
         expected = "SELECT 'it''s' FROM t "
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'handles SQL-style escaped double quotes' do
         sql = 'SELECT "col""name" FROM t -- comment'
         expected = 'SELECT "col""name" FROM t '
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'handles backslash-escaped quotes' do
         sql = "SELECT 'it\\'s' FROM t -- comment"
         expected = "SELECT 'it\\'s' FROM t "
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
     end
 
     context 'with dollar-quoted strings' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'preserves comments in simple dollar quotes' do
         sql = 'SELECT $$text with -- comment$$ FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves comments in tagged dollar quotes' do
         sql = 'SELECT $tag$text with /* comment */$tag$ FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'handles multiple dollar-quoted strings' do
         sql = 'SELECT $$-- c1$$, $t$/* c2 */$t$ FROM t -- real comment'
         expected = 'SELECT $$-- c1$$, $t$/* c2 */$t$ FROM t '
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'handles nested dollar quotes with different tags' do
         sql = 'SELECT $outer$text $inner$nested$inner$$outer$ FROM t'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
     end
 
     context 'with inline comments' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'removes inline block comments' do
         sql = 'SELECT /* comment */ column FROM t'
         expected = 'SELECT  column FROM t'
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'removes multiple inline comments' do
         sql = 'SELECT /* c1 */ col1, /* c2 */ col2 FROM t'
         expected = 'SELECT  col1,  col2 FROM t'
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
     end
 
     context 'with comments containing quotes' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'handles single-line comments with quotes' do
         sql = "SELECT * FROM t -- comment with 'quotes' and \"more\"\nWHERE id = 1"
         expected = "SELECT * FROM t \nWHERE id = 1"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'handles multi-line comments with quotes' do
         sql = "SELECT * FROM t /* comment with 'quotes' and \"more\" */ WHERE id = 1"
         expected = 'SELECT * FROM t  WHERE id = 1'
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
     end
 
     context 'with edge cases' do
-      let(:remover) { described_class.new(:all) }
+      let(:config) { build_config(remove_comments: :all) }
+      let(:remover) { described_class.new(config) }
 
       it 'handles empty SQL' do
-        expect(remover.remove('')).to eq('')
+        expect(remover.remove('', for_logs: true)).to eq('')
       end
 
       it 'handles SQL with only comments' do
         sql = "-- comment 1\n/* comment 2 */"
         expected = "\n"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
       end
 
       it 'handles SQL with no comments' do
         sql = 'SELECT * FROM t WHERE id = 1'
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'handles comment-like patterns that are not comments' do
         sql = "SELECT * FROM t WHERE url = 'http://example.com' AND x = 1"
-        expect(remover.remove(sql)).to eq(sql)
+        expect(remover.remove(sql, for_logs: true)).to eq(sql)
       end
 
       it 'preserves newlines from removed single-line comments' do
         sql = "SELECT *\n-- comment\nFROM t"
         expected = "SELECT *\n\nFROM t"
-        expect(remover.remove(sql)).to eq(expected)
+        expect(remover.remove(sql, for_logs: true)).to eq(expected)
+      end
+    end
+
+    context 'with remove_comments_from configuration' do
+      let(:sql) { "SELECT * FROM t -- comment\nWHERE id = 1" }
+      let(:expected) { "SELECT * FROM t \nWHERE id = 1" }
+
+      context 'when remove_comments_from is :all' do
+        let(:config) { build_config(remove_comments: :all, remove_comments_from: :all) }
+        let(:remover) { described_class.new(config) }
+
+        it 'removes comments for logs' do
+          expect(remover.remove(sql, for_logs: true)).to eq(expected)
+        end
+
+        it 'removes comments for non-logs' do
+          expect(remover.remove(sql, for_logs: false)).to eq(expected)
+        end
+      end
+
+      context 'when remove_comments_from is :prepared_for_logs' do
+        let(:config) { build_config(remove_comments: :all, remove_comments_from: :prepared_for_logs) }
+        let(:remover) { described_class.new(config) }
+
+        it 'removes comments for logs' do
+          expect(remover.remove(sql, for_logs: true)).to eq(expected)
+        end
+
+        it 'keeps comments for non-logs' do
+          expect(remover.remove(sql, for_logs: false)).to eq(sql)
+        end
+      end
+
+      context 'when remove_comments_from is :none' do
+        let(:config) { build_config(remove_comments: :all, remove_comments_from: :none) }
+        let(:remover) { described_class.new(config) }
+
+        it 'keeps comments for logs' do
+          expect(remover.remove(sql, for_logs: true)).to eq(sql)
+        end
+
+        it 'keeps comments for non-logs' do
+          expect(remover.remove(sql, for_logs: false)).to eq(sql)
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

This PR introduces a comprehensive SQL comment removal system that addresses #20. The feature allows developers to configure how and when SQL comments are removed from queries, providing flexibility for different use cases (debugging, logging, production).

## Key Features

- **Configurable removal strategies** (`config.remove_comments`):
  - `:none` - Don't remove any comments
  - `:oneline` - Remove only single-line comments (`--`)
  - `:multiline` - Remove only multi-line comments (`/* */`)
  - `:all` - Remove both types (default)

- **Configurable scope** (`config.remove_comments_from`):
  - `:none` - Don't remove comments anywhere
  - `:prepared_for_logs` - Remove comments only in `prepared_for_logs` method
  - `:all` - Remove comments from all queries (default)

- **SQL Standard Compliance**:
  - Follows SQL-92 comment syntax
  - Supports all major databases (PostgreSQL, MySQL, Oracle, SQL Server, SQLite)
  - Preserves comments within quoted strings:
    - Single quotes: `'-- not a comment'`
    - Double quotes: `"-- not a comment"`
    - Dollar quotes (PostgreSQL): `$$-- not a comment$$`, `$tag$-- not a comment$tag$`

- **Edge Case Handling**:
  - SQL-style escaped quotes (`''`, `""`)
  - Backslash-escaped quotes (`\'`, `\"`)
  - Comments without trailing newlines
  - Inline comments
  - Multiple comments of different types
  - Comments containing quote characters

## Implementation Approach

### State Machine Pattern

This implementation uses a state machine approach rather than complex regex for several reasons:

1. **Easier to Debug**: Character-by-character processing with clear state tracking
2. **Better Edge Case Handling**: Tracks multiple quote types simultaneously
3. **Maintainable**: Easy to understand and extend
4. **Reliable**: Handles nested quote types correctly

### Architecture

- **CommentRemover Service Class** (`lib/sql_query/comment_remover.rb`):
  - Implements state machine for comment removal
  - Handles all quote types and escape sequences
  - SQL-92 standard compliant

- **Config Class Extraction** (`lib/sql_query/config.rb`):
  - Extracted to separate file for better organization
  - Added `should_comments_be_removed?(for_logs:)` method for clean logic
  - Reduces SqlQuery class complexity

- **Integration Points**:
  - `SqlQuery#sql` - Applies removal based on configuration
  - `SqlQuery#prepared_for_logs` - Applies removal based on configuration
  - `SqlQuery#apply_comment_removal` - Helper method with clean logic

## Testing

- **78 total test examples**, 0 failures
- **98.38% code coverage**
- **CommentRemover unit tests**: 32 examples covering all scenarios
- **Integration tests**: 10 examples for configuration combinations
- **Config tests**: 12 examples for configuration behavior
- **Test fixtures**: 5 SQL templates with various comment scenarios
- **RuboCop compliant**: All style checks pass

## Documentation

- **CHANGELOG.md**: Updated with feature description
- **README.md**: Added configuration examples and detailed option descriptions

## Default Behavior

By default, both comment types are removed from all queries:

```ruby
SqlQuery.configure do |config|
  config.remove_comments = :all        # Remove both -- and /* */
  config.remove_comments_from = :all   # From both sql() and prepared_for_logs()
end
```

## Migration Path

This is a backwards-compatible addition:
- Default behavior removes comments (improves log readability)
- Can be disabled by setting `config.remove_comments = :none`
- Can be scoped to only logs with `config.remove_comments_from = :prepared_for_logs`

## Test Plan

- [x] All existing tests pass
- [x] New unit tests for CommentRemover service
- [x] New integration tests for configuration scenarios
- [x] Config class tests
- [x] RuboCop compliance verified
- [x] Manual testing with various SQL patterns

Addresses #20